### PR TITLE
Update bochs-full.rb

### DIFF
--- a/Formula/bochs-full.rb
+++ b/Formula/bochs-full.rb
@@ -56,7 +56,9 @@ class BochsFull < Formula
     ]
     # Debug support
     if build.with?("debugger-internal") && build.with?("debugger-gdb-stub")
-      odie "Internal debugger and GDB stub are mutually exclusive! If you're using 'brew reinstall', try using 'brew uninstall' and 'brew install' instead."
+      opoo "Internal debugger and GDB stub are mutually exclusive!"
+      ohai "If you're using 'brew reinstall', try using 'brew uninstall' and 'brew install' instead."
+      odie "Exiting install, please try again with one only one debug options."
     end
     if build.with?("debugger-internal")
       args << "--enable-debugger"

--- a/Formula/bochs-full.rb
+++ b/Formula/bochs-full.rb
@@ -56,7 +56,7 @@ class BochsFull < Formula
     ]
     # Debug support
     if build.with?("debugger-internal") && build.with?("debugger-gdb-stub")
-      odie "Internal debugger and GDB stub are mutually exclusive!"
+      odie "Internal debugger and GDB stub are mutually exclusive! If you're using 'brew reinstall', try using 'brew uninstall' and 'brew install' instead."
     end
     if build.with?("debugger-internal")
       args << "--enable-debugger"


### PR DESCRIPTION
Expanded error message for both debugger options to address an error case that is likely to be common.

Using brew reinstall will probably feel like the easier option and is likely to be chosen, however it seems to keep the previously installed options as well as added ones, which doesn’t work for mutually exclusive options such as these debugging options.

The new error message prompts the user to run an uninstall, then an install, which will avoid this issue.